### PR TITLE
Allow multiple replacements on a single message

### DIFF
--- a/views/preload.js
+++ b/views/preload.js
@@ -44,13 +44,13 @@
   function processMessage (msg) {
     // console.log(msg);
     if (msg.startsWith('&gt;'))
-      return "<span class='greentext'>" + msg + "</span>";
+      msg = "<span class='greentext'>" + msg + "</span>";
 
-    if (msg.startsWith('[CODE]<br>')) {
-      return "<code>" + hl.highlightAuto(msg.substr(10).replace(/<br>/g, "\n").replace(/&lt;/g,'<').replace(/&gt;/g,'>')).value + "</code>";
+    else if (msg.startsWith('[CODE]<br>')) {
+      msg = "<code>" + hl.highlightAuto(msg.substr(10).replace(/<br>/g, "\n").replace(/&lt;/g,'<').replace(/&gt;/g,'>')).value + "</code>";
     }
 
-    if (msg.startsWith('[haskell]')) {
+    else if (msg.startsWith('[haskell]')) {
       var code = msg.substr(9).replace(/<br>/g, "\n").replace(/&lt;/g,'<').replace(/&gt;/g,'>');
       var id   = Math.floor(Math.random() * 1000);
       
@@ -61,12 +61,12 @@
         el.outerHTML = "<code>" + hl.highlight("haskell", "-- Result:\n" + r).value + "</code>";
       });
 
-      return "<code>" + hl.highlight("haskell", code).value + "</code>" 
-           + "<span class='snippet' id='" + id + "'>Calculating..</span>";
+      msg = "<code>" + hl.highlight("haskell", code).value + "</code>" 
+            + "<span class='snippet' id='" + id + "'>Calculating..</span>";
     }
     
-    msg = msg.replace(/windows/gi, "<span class='gay'>windows</span>");
-    msg = msg.replace(/linux/gi, "<span class='cool'>Linux</span>");
+    msg = msg.replace(/windows/gi, "<span class='gay'>window$</span>");
+    msg = msg.replace(/linux/gi, "<span class='cool'>$&</span>");
     msg = msg.replace(/`(.+?)`/g, "<span class='snippet'>$1</span>");
 
     return msg;

--- a/views/preload.js
+++ b/views/preload.js
@@ -72,11 +72,15 @@
     return msg;
   }
 
+  function isKeyEscape(event) {
+    return event.key == "Escape" || event.key == "Esc" || event.keyCode == 27 || (event.key == "[" && event.ctrlKey);
+  }
+
 	function stopIt(event) {
     // console.log(event);
 
     if (event.srcElement.id == "chatInputAreaWithQuotes") {
-      if (event.key == "Escape" || event.key == "Esc" || event.keyCode == 27) {
+      if (isKeyEscape(event)) {
         var hs = document.getElementsByClassName('conversationHistory');
 
         for (let i = 0; i < hs.length; i++) {
@@ -85,7 +89,7 @@
           return hs[i].querySelector('.conversation').focus();
         }
       }
-    } else if (findMode && (event.key == "Escape" || event.key == "Esc" || event.keyCode == 27)) {
+    } else if (findMode && isKeyEscape(event)) {
       for (let i = 0; i < finds.length; i++)
         finds[i][2].parentElement.removeChild(finds[i][2]);
       findMode = false;


### PR DESCRIPTION
Made it possible to have `> green text` and `` `code snippets` `` in one message.

Instead of directly returning the replaced value, I store the replacement and apply the next three after that.

Also, the capitalization of the *`linux`* word is kept by replacing it using `$&`, instead of the plain `linux` text.